### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/preview-dvisvgm.el
+++ b/preview-dvisvgm.el
@@ -47,6 +47,8 @@
 ;;; Code:
 
 (require 'preview)
+(require 'cl-lib)
+(require 'face-remap)
 
 (defcustom preview-dvisvgm-debug 0
   "Verbosity level for debugging of preview-dvisvgm."
@@ -71,10 +73,10 @@
 
 (gv-define-simple-setter preview-dvisvgm-variable-standard-value preview-dvisvgm-set-variable-standard-value)
 
-(pushnew '(dvisvgm (open preview-gs-open preview-dvisvgm-process-setup)
-		   (place preview-gs-place)
-		   (close preview-dvisvgm-close))
-	 (preview-dvisvgm-variable-standard-value 'preview-image-creators))
+(cl-pushnew '(dvisvgm (open preview-gs-open preview-dvisvgm-process-setup)
+		      (place preview-gs-place)
+		      (close preview-dvisvgm-close))
+	    (preview-dvisvgm-variable-standard-value 'preview-image-creators))
 
 (put 'preview-image-type 'custom-type
      (append '(choice)


### PR DESCRIPTION
```
In preview-dvisvgm-start:
preview-dvisvgm.el:140:26: Warning: reference to free variable
    ‘text-scale-mode’
preview-dvisvgm.el:141:30: Warning: reference to free variable
    ‘text-scale-mode-step’
preview-dvisvgm.el:141:51: Warning: reference to free variable
    ‘text-scale-mode-amount’

In end of data:
preview-dvisvgm.el:74:2: Warning: the function ‘pushnew’ is not known to be
    defined.
```